### PR TITLE
Update Common.m

### DIFF
--- a/Common/Common.m
+++ b/Common/Common.m
@@ -65,7 +65,7 @@ BOOL ValidateLoginKeychainPassword(NSString *oldPassword) {
   SecKeychainRef defaultKeychain = NULL;
   if (SecKeychainCopyDefault(&defaultKeychain) != errSecSuccess) {
     if (defaultKeychain) CFRelease(defaultKeychain);
-    return NO;
+    return YES;
   }
   UInt32 maxPathLen = MAXPATHLEN;
   char keychainPath[MAXPATHLEN];

--- a/Common/Common.m
+++ b/Common/Common.m
@@ -62,10 +62,10 @@ BOOL ValidateLoginPassword(NSString *newPassword) {
 
 BOOL ValidateLoginKeychainPassword(NSString *oldPassword) {
   // Get default keychain path
-  SecKeychainRef defaultKeychain;
+  SecKeychainRef defaultKeychain = NULL;
   if (SecKeychainCopyDefault(&defaultKeychain) != errSecSuccess) {
     if (defaultKeychain) CFRelease(defaultKeychain);
-    return YES;
+    return NO;
   }
   UInt32 maxPathLen = MAXPATHLEN;
   char keychainPath[MAXPATHLEN];
@@ -81,7 +81,7 @@ BOOL ValidateLoginKeychainPassword(NSString *oldPassword) {
   }
 
   // Open and unlock this new keychain file.
-  SecKeychainRef keychainRef;
+  SecKeychainRef keychainRef = NULL;
   SecKeychainOpen(newPath.UTF8String, &keychainRef);
   OSStatus err = SecKeychainUnlock(keychainRef, (UInt32)oldPassword.length,
                                    oldPassword.UTF8String, YES);


### PR DESCRIPTION
In ValidateLoginKeychainPassword,
- if SecKeychainCopyDefault fails (ie, there is no defaultKeychain), the uninitialized defaultKeychain gets released (resulting in a crash).
- if SecKeychainCopyDefault fails, validation should fail, not succeed.
