### PR TITLE
Update uninstall.sh

### DIFF
--- a/KeychainMinder/uninstall.sh
+++ b/KeychainMinder/uninstall.sh
@@ -18,7 +18,7 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-/usr/bin/env python /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle/Contents/Resources/update_authdb.py remove
+/usr/bin/env python /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle/Contents/Resources/update_authdb.py remove --restore-screensaver
 /bin/rm -rf /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle
 /bin/rm /Library/LaunchAgents/com.google.corp.keychainminder.plist
 /bin/rm /Library/Preferences/com.google.corp.keychainminder.plist

--- a/KeychainMinder/uninstall.sh
+++ b/KeychainMinder/uninstall.sh
@@ -18,7 +18,17 @@ if [[ $EUID -ne 0 ]]; then
   exit 1
 fi
 
-/usr/bin/env python /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle/Contents/Resources/update_authdb.py remove --restore-screensaver
+updatearg=""
+for arg in $*; do
+  if [ "$arg" == "--restore-screensaver" ]; then
+    updatearg=$arg
+  else
+    echo "unknown argument: $arg"
+    exit 1
+  fi
+done
+
+/usr/bin/env python /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle/Contents/Resources/update_authdb.py remove $updatearg
 /bin/rm -rf /Library/Security/SecurityAgentPlugins/KeychainMinder.bundle
 /bin/rm /Library/LaunchAgents/com.google.corp.keychainminder.plist
 /bin/rm /Library/Preferences/com.google.corp.keychainminder.plist


### PR DESCRIPTION
screensaver behavior did not revert to the new UI when I disabled keychainminder.  Re-running the update_authdb.py script with remove --restore-screensaver seemed to be needed.
