### PR TITLE
Use the "authenticate" right

### DIFF
--- a/Common/Common.m
+++ b/Common/Common.m
@@ -30,7 +30,7 @@ void SetUsers(NSMutableArray *usersArray) {
 
 BOOL ValidateLoginPassword(NSString *newPassword) {
   AuthorizationItem right;
-  right.name = "system.login.tty";
+  right.name = "authenticate";
   right.value = NULL;
   right.valueLength = 0;
   right.flags = 0;


### PR DESCRIPTION
`system.login.tty` uses the `default` rule which requires `admin` group membership.

security authorizationdb read system.login.tty

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>class</key>
    <string>rule</string>
    <key>created</key>
    <real>477499297.08687699</real>
    <key>modified</key>
    <real>477499297.08687699</real>
    <key>rule</key>
    <array>
        <string>default</string>
    </array>
    <key>version</key>
    <integer>1</integer>
</dict>
</plist>
```

security authorizationdb read default

``` xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>allow-root</key>
    <false/>
    <key>authenticate-user</key>
    <true/>
    <key>class</key>
    <string>user</string>
    <key>comment</key>
    <string>Default rule.
            Credentials remain valid for 5 minutes after they've been obtained.
            An acquired credential is shared by all clients.
            </string>
    <key>created</key>
    <real>477499297.08687699</real>
    <key>group</key>
    <string>admin</string>
    <key>modified</key>
    <real>477499297.08687699</real>
    <key>session-owner</key>
    <false/>
    <key>shared</key>
    <true/>
    <key>timeout</key>
    <integer>300</integer>
    <key>tries</key>
    <integer>10000</integer>
    <key>version</key>
    <integer>0</integer>
</dict>
</plist>
```

To fix this we will use the `authenticate` right to check the user's password. This seems to work okay in testing. We should keep an eye on this in case a calling loop occurs because `KeychainMinder:check,privileged` in apart of `authenticate`.

Associated Issues:
-  https://github.com/google/macops-keychainminder/issues/10
