### PR TITLE
Run script with python 2.7 on Mac

### DIFF
--- a/KeychainMinder/update_authdb.py
+++ b/KeychainMinder/update_authdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2.7
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/KeychainMinder/update_authdb.py
+++ b/KeychainMinder/update_authdb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # Copyright 2015 Google Inc. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Fixes https://github.com/google/macops-keychainminder/issues/20